### PR TITLE
docs: fix the example so that it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,36 @@ A framework for building create web apps – powered by Gleam and React!
 ```gleam
 import gleam/int
 import lustre
-import lustre/element.{ button, div, p, text }
-import lustre/event.{ dispatch, on_click }
+import lustre/element.{button, div, p, text}
+import lustre/event.{dispatch, on_click}
+import lustre/cmd
 
-pub fn main () {
-    let app = lustre.application(0, update, render)
-    lustre.start(app, "#app")
+pub fn main() {
+  let app = lustre.application(#(0, cmd.none()), update, render)
+  lustre.start(app, "#app")
 }
 
-type Action {
-    Incr
-    Decr
+pub type Action {
+  Incr
+  Decr
 }
 
-fn update (state, action) {
-    case action {
-        Incr -> state + 1
-        Decr -> state - 1
-    }
+fn update(state, action) {
+  case action {
+    Incr -> #(state + 1, cmd.none())
+    Decr -> #(state - 1, cmd.none())
+  }
 }
 
-fn render (state) {
-    div([], [
-        button([ on_click(dispatch(Decr)) ], [ text("-") ]),
-        p([], [ text(int.to_string(state)) ]),
-        button([ on_click(dispatch(Incr)) ], [ text("+") ])
-    ])
+fn render(state) {
+  div(
+    [],
+    [
+      button([on_click(dispatch(Decr))], [text("-")]),
+      p([], [text(int.to_string(state))]),
+      button([on_click(dispatch(Incr))], [text("+")]),
+    ],
+  )
 }
 ```
 


### PR DESCRIPTION
I had to change the init and update function to use a tuple of #(state, cmd) and to make the Action type public. Gleam format added some noise to the diff