### PR TITLE
output `htmlFor` instead of `for`

### DIFF
--- a/src/lustre/attribute.gleam
+++ b/src/lustre/attribute.gleam
@@ -143,7 +143,7 @@ pub fn required(is_required: Bool) -> Attribute(msg) {
 
 ///
 pub fn for(id: String) -> Attribute(msg) {
-  attribute("for", id)
+  attribute("htmlFor", id)
 }
 
 // INPUT RANGES ----------------------------------------------------------------


### PR DESCRIPTION
`for` can't be use in JS as it's a reserved keyword, so react renamed the property to `htmlFor`