### PR TITLE
Fix: avoid a race condition when dispatch is used twice from outside

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
+  { name = "gleam_stdlib", version = "0.27.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "9DBDD21B48C654182CDD8AA15ACF85E8E74A0438583C68BD7EF08BE89F999C6F" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
 ]
 

--- a/test/example/application/counter.gleam
+++ b/test/example/application/counter.gleam
@@ -5,7 +5,7 @@ import lustre
 import lustre/attribute.{ style }
 import lustre/cmd.{ Cmd }
 import lustre/element.{ button, div, p, text }
-import lustre/event.{ dispatch, on_click }
+import lustre/event.{ on_click }
 
 // MAIN ------------------------------------------------------------------------
 
@@ -79,8 +79,8 @@ fn tick () -> Cmd(Action) {
 
 pub fn render (state) {
     div([ style([ #("display", "flex") ]) ], [
-        button([ on_click(dispatch(Decr)) ], [ text("-") ]),
+        button([ on_click(Decr) ], [ text("-") ]),
         p([], [ int.to_string(state.count) |> text ]),
-        button([ on_click(dispatch(Incr)) ], [ text("+") ])
+        button([ on_click(Incr) ], [ text("+") ]),
     ])
 }

--- a/test/example/application/counter.gleam
+++ b/test/example/application/counter.gleam
@@ -16,7 +16,7 @@ pub fn main () -> Nil {
     // `lustre.start` can return an `Error` if no DOM element is found that matches
     // the selector. This is a fatal error for our examples, so we panic if that 
     // happens.
-    assert Ok(_) = lustre.start(program, selector)
+    let assert Ok(_) = lustre.start(program, selector)
 
     Nil
 }
@@ -77,7 +77,7 @@ fn tick () -> Cmd(Action) {
 
 // RENDER ----------------------------------------------------------------------
 
-pub fn render (state) {
+pub fn render (state: State) {
     div([ style([ #("display", "flex") ]) ], [
         button([ on_click(Decr) ], [ text("-") ]),
         p([], [ int.to_string(state.count) |> text ]),

--- a/test/example/main.gleam
+++ b/test/example/main.gleam
@@ -15,7 +15,7 @@ pub fn main () -> Nil {
     // `lustre.start` can return an `Error` if no DOM element is found that matches
     // the selector. This is a fatal error for our examples, so we panic if that 
     // happens.
-    assert Ok(dispatch) = lustre.start(program, selector)
+    let assert Ok(dispatch) = lustre.start(program, selector)
 
     dispatch(Counter(counter.Incr))
     dispatch(Counter(counter.Incr))

--- a/test/playground/monaco.gleam
+++ b/test/playground/monaco.gleam
@@ -8,7 +8,7 @@ pub external fn render (attributes: List(Attribute(action))) -> Element(action)
 
 pub fn on_change (handler: fn (String, fn (action) -> Nil) -> Nil) -> Attribute(action) {
     event.on("change", fn (e, dispatch) {
-        assert Ok(code) = dynamic.string(e)
+        let assert Ok(code) = dynamic.string(e)
 
         handler(code, dispatch)
     })


### PR DESCRIPTION
3-in-1

Fix: avoid a race condition when dispatch is used twice from outside

E.g. websocket open + websocket msg arriving
Application returns a Cmd from update(model, msg)
but the Effect handler is *not* ran be React 18 before
the websocket msg-arriving is handled by the Reducer.
Result: The Cmd returned by update(model, msg) is dropped silently.